### PR TITLE
Fix: inject global settings early to prevent false warnings

### DIFF
--- a/maple/function/read/input_reader.py
+++ b/maple/function/read/input_reader.py
@@ -200,6 +200,19 @@ class InputReader():
                     atoms_or_list = processed_list
                 else:
                     atoms_or_list = self.post_processing_command(expanded_post_processing, atoms_or_list)
+        # =========================================================
+        # [Fix] Inject global settings into atoms.info to avoid warnings
+        # =========================================================
+        # Ensure 'task', 'charge', 'spin', 'model' etc. are passed to the Atoms object
+        if hasattr(self, 'command_control'):
+            global_settings = self.command_control.as_dict()
+            
+            if isinstance(atoms_or_list, list):
+                for at in atoms_or_list:
+                    at.info.update(global_settings)
+            else:
+                atoms_or_list.info.update(global_settings)
+        # =========================================================
 
         # Return Atoms if single structure, Molecules if multiple
         if isinstance(atoms_or_list, list):


### PR DESCRIPTION
**Summary**
This PR resolves a false positive warning issue where the logger incorrectly flagged missing `charge` and `spin` settings (defaulting to `task='omol'`) during initialization, even when they were correctly specified in the input file.

**Key changes**
**InputReader:**

* Explicitly inject global settings (task, charge, spin, model) from `command_control` into the `Atoms.info` dictionary immediately after parsing.
* Eliminate the logic gap where the Logger validated the `Atoms` object before input parameters were fully assigned.

**Bug Description:**
Previously, the execution flow caused misleading warnings:

1. **Initialization:** The molecular container initialized with defaults (`Task='omol'`, `Charge=None`).
2. **False Warning:** The Logger checked these defaults and issued warnings immediately *before* the input file was fully processed.
3. **Correction:** The `InputReader` parsed the correct values (e.g., `# task=opt`) later, overwriting the defaults for the actual calculation.
4. **Result:** The job ran correctly (as seen in `.out`), but the terminal displayed confusing warnings.

This fix ensures `atoms.info` is populated before downstream validation occurs.