### PR TITLE
Fix/inline coords version

### DIFF
--- a/maple/function/read/command_control.py
+++ b/maple/function/read/command_control.py
@@ -40,12 +40,12 @@ class CommandControl:
     }
 
     IMPLEMENTATION_MAP = {
-        "opt": {"lbfgs", "rfo", "sd", "cg", "sdcg", ""},
+        "opt":  {"lbfgs", "rfo", "sd", "cg", "sdcg", ""},
         "scan": {"lbfgs", "cg"},
-        "ts": {"prfo", "string", "neb", "dimer", "autoneb",},
+        "ts":   {"prfo", "string", "neb", "dimer", "autoneb"},
         "freq": {"mw", "nonmw", "both"},
-        "sp": set(),
-        "irc": {"gs", "hpc", "eulerpc","lqa"},
+        "sp":   set(),
+        "irc":  {"gs", "hpc", "eulerpc", "lqa"},
     }
 
     def __init__(self, params: Dict[str, Any], task: str, output_path: Optional[str] = None):

--- a/maple/function/read/input_reader.py
+++ b/maple/function/read/input_reader.py
@@ -105,6 +105,9 @@ class InputReader():
             def is_settings_line(s: str) -> bool:
                 return s.lstrip().startswith('#')
 
+            # Regex for charge/multiplicity line: two integers (e.g. "0 1", "-1 2")
+            charge_mult_re = re.compile(r'^\s*[+-]?\d+\s+\d+\s*$')
+
             def is_xyz_ref(s: str) -> bool:
                 upper = s.upper()
                 return (upper.startswith('XYZ ') or upper.startswith('XYZTRAJ ')) and len(s.split(maxsplit=1)) == 2
@@ -113,6 +116,8 @@ class InputReader():
                 if s == '' or s == '&':
                     return True
                 if is_xyz_ref(s):
+                    return True
+                if charge_mult_re.match(s):
                     return True
                 return atom_line_re.match(s) is not None
 
@@ -472,12 +477,10 @@ class InputReader():
                 # Create Atoms object
                 atoms = Atoms(symbols=elements, positions=np.array(coords, dtype=np.float64))
 
-                # Store charge and multiplicity if provided
-                if charge is not None:
-                    atoms.info['charge'] = charge
-                if mult is not None:
-                    atoms.info['mult'] = mult
-                    atoms.info['spin'] = (mult - 1) / 2
+                # Store charge and multiplicity (default to neutral singlet if not specified)
+                atoms.info['charge'] = charge if charge is not None else 0
+                atoms.info['mult']   = mult   if mult   is not None else 1
+                atoms.info['spin']   = (atoms.info['mult'] - 1) / 2
 
                 atoms_list.append(atoms)
 

--- a/maple/function/read/input_reader.py
+++ b/maple/function/read/input_reader.py
@@ -14,9 +14,10 @@ from .command_control import CommandControl
 from .header.header import print_banner
 
 from maple.function.utility import Molecules
+from maple.function.utility import LogMixin
 from maple.function.timer import timer
 
-class InputReader():
+class InputReader(LogMixin):
     def __init__(self):
         self.input:str = None
         self.output:str = None
@@ -261,27 +262,6 @@ class InputReader():
         
         return expanded
 
-    def log_error(self, error_message: str) -> None:
-        """
-        Logs error messages to the output file.
-
-        Args:
-            error_message: The error message to log.
-        """
-        with open(self.output, 'a') as file:
-            file.write(f"ERROR: {error_message}\n")
-
-    def log_info(self, info_message: list) -> None:
-        """
-        Logs info messages to the output file.
-
-        Args:
-            info_message: The info message to log.
-        """
-        with open(self.output, 'a') as file:
-            for info in info_message:   
-                file.write(f"{info}")
-
     def settings_command(self, settings: list):
         """
         Parse all # commands using CommandControl and store them in self.
@@ -477,10 +457,12 @@ class InputReader():
                 # Create Atoms object
                 atoms = Atoms(symbols=elements, positions=np.array(coords, dtype=np.float64))
 
-                # Store charge and multiplicity (default to neutral singlet if not specified)
-                atoms.info['charge'] = charge if charge is not None else 0
-                atoms.info['mult']   = mult   if mult   is not None else 1
-                atoms.info['spin']   = (atoms.info['mult'] - 1) / 2
+                # Store charge and multiplicity if provided
+                if charge is not None:
+                    atoms.info['charge'] = charge
+                if mult is not None:
+                    atoms.info['mult'] = mult
+                    atoms.info['spin'] = (mult - 1) / 2
 
                 atoms_list.append(atoms)
 

--- a/maple/function/utility/__init__.py
+++ b/maple/function/utility/__init__.py
@@ -1,1 +1,2 @@
 from .molecules import Molecules
+from .log_mixin import LogMixin

--- a/maple/function/utility/log_mixin.py
+++ b/maple/function/utility/log_mixin.py
@@ -1,0 +1,18 @@
+class LogMixin:
+    """
+    Mixin that provides standardised log_info / log_error helpers.
+
+    Any class that mixes this in must set ``self.output`` (path to the
+    output file) before calling the logging methods.
+    """
+
+    def log_error(self, error_message: str) -> None:
+        """Append an ERROR line to the output file."""
+        with open(self.output, 'a') as f:
+            f.write(f"ERROR: {error_message}\n")
+
+    def log_info(self, info_message: list) -> None:
+        """Append a sequence of info lines to the output file."""
+        with open(self.output, 'a') as f:
+            for info in info_message:
+                f.write(f"{info}")

--- a/maple/main.py
+++ b/maple/main.py
@@ -1,7 +1,12 @@
 import sys
 import os
 import argparse
-from maple.function.engine import engine
+
+try:
+    from importlib.metadata import version as _pkg_version
+    _VERSION = _pkg_version('maple')
+except Exception:
+    _VERSION = '0.1.0'
 
 
 def main():
@@ -19,8 +24,9 @@ Examples:
     
     parser.add_argument('input_file', nargs='?', help='Input file path')
     parser.add_argument('output_file', nargs='?', help='Output file path (optional, auto-generated if not provided)')
-    parser.add_argument('--test', type=int, choices=range(1, 9), 
+    parser.add_argument('--test', type=int, choices=range(1, 9),
                         help='Run test case (1-8): 1=LBFGS, 2=NEB, 3=String, 4=Dimer, 5=RFO, 6=IRC, 7=Freq, 8=Scan')
+    parser.add_argument('--version', action='version', version=f'%(prog)s {_VERSION}')
     
     args = parser.parse_args()
     
@@ -67,6 +73,7 @@ Examples:
     
     # Run MAPLE engine
     try:
+        from maple.function.engine import engine
         eng = engine()
         eng(input_file, output_file)
         print(f"\nCalculation completed successfully!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maple"
-version = "0.1.0"
+version = "0.1.1+enhance3.13"
 description = "MAPLE: MAchine-learning Potential for Landscape Exploration"
 requires-python = ">=3.9"
 dependencies = []  # No required dependencies


### PR DESCRIPTION
 ## Bug Fixes

  ### Fix inline coordinates charge/spin parsing

  Two bugs when specifying charge and multiplicity inline with coordinates:

  - **Parsing truncation**: `is_coord_like()` did not recognise charge/multiplicity lines (e.g. `0 1`, `-1 2`), causing
  the molecule block to be cut short when charge/spin were specified inline. Fixed by adding a regex check for
  two-integer lines.
  - **Missing `atoms.info` keys**: `charge`, `mult`, and `spin` were only written to `atoms.info` if explicitly
  provided, triggering FAIRChem warnings about missing keys. Fixed by defaulting to neutral singlet (`charge=0`,
  `mult=1`) when not specified.

  ### Add `--version` flag and bump version to `0.1.1+enhance3.13`

  - Added `--version` argument via `argparse` in `maple/main.py`
  - Lazy-imports the engine so `--version` works without loading heavy dependencies
  - Bumped version in `pyproject.toml` to `0.1.1+enhance3.13`