### PR TITLE
Fix inline coordinate parsing, log method bugs, and add --version flag

### DIFF
--- a/maple/function/read/command_control.py
+++ b/maple/function/read/command_control.py
@@ -40,12 +40,12 @@ class CommandControl:
     }
 
     IMPLEMENTATION_MAP = {
-        "opt": {"lbfgs", "rfo", "sd", "cg", "sdcg", ""},
+        "opt":  {"lbfgs", "rfo", "sd", "cg", "sdcg", ""},
         "scan": {"lbfgs", "cg"},
-        "ts": {"prfo", "string", "neb", "dimer", "autoneb",},
+        "ts":   {"prfo", "string", "neb", "dimer", "autoneb"},
         "freq": {"mw", "nonmw", "both"},
-        "sp": set(),
-        "irc": {"gs", "hpc", "eulerpc","lqa"},
+        "sp":   set(),
+        "irc":  {"gs", "hpc", "eulerpc", "lqa"},
     }
 
     def __init__(self, params: Dict[str, Any], task: str, output_path: Optional[str] = None):

--- a/maple/function/read/input_reader.py
+++ b/maple/function/read/input_reader.py
@@ -105,6 +105,9 @@ class InputReader():
             def is_settings_line(s: str) -> bool:
                 return s.lstrip().startswith('#')
 
+            # Regex for charge/multiplicity line: two integers (e.g. "0 1", "-1 2")
+            charge_mult_re = re.compile(r'^\s*[+-]?\d+\s+\d+\s*$')
+
             def is_xyz_ref(s: str) -> bool:
                 upper = s.upper()
                 return (upper.startswith('XYZ ') or upper.startswith('XYZTRAJ ')) and len(s.split(maxsplit=1)) == 2
@@ -113,6 +116,8 @@ class InputReader():
                 if s == '' or s == '&':
                     return True
                 if is_xyz_ref(s):
+                    return True
+                if charge_mult_re.match(s):
                     return True
                 return atom_line_re.match(s) is not None
 
@@ -257,24 +262,14 @@ class InputReader():
         return expanded
 
     def log_error(self, error_message: str) -> None:
-        """
-        Logs error messages to the output file.
-
-        Args:
-            error_message: The error message to log.
-        """
+        """Logs error messages to the output file."""
         with open(self.output, 'a') as file:
             file.write(f"ERROR: {error_message}\n")
 
     def log_info(self, info_message: list) -> None:
-        """
-        Logs info messages to the output file.
-
-        Args:
-            info_message: The info message to log.
-        """
+        """Logs info messages to the output file."""
         with open(self.output, 'a') as file:
-            for info in info_message:   
+            for info in info_message:
                 file.write(f"{info}")
 
     def settings_command(self, settings: list):
@@ -298,13 +293,13 @@ class InputReader():
                 if torch.cuda.is_available():
                     self.device = torch.device(f'cuda:{cuda_idx}')
                 else:
-                    self.log_info("\nWARNING: CUDA is not available. Falling back to CPU.\n")
+                    self.log_info(["\nWARNING: CUDA is not available. Falling back to CPU.\n"])
                     self.device = torch.device('cpu')
             else:
                 try:
                     self.device = torch.device(dev_str)
                 except:
-                    self.log_info("\nWARNING: Unrecognized device. Falling back to CPU.\n")
+                    self.log_info(["\nWARNING: Unrecognized device. Falling back to CPU.\n"])
                     self.device = torch.device('cpu')
 
             

--- a/maple/main.py
+++ b/maple/main.py
@@ -1,7 +1,12 @@
 import sys
 import os
 import argparse
-from maple.function.engine import engine
+
+try:
+    from importlib.metadata import version as _pkg_version
+    _VERSION = _pkg_version('maple')
+except Exception:
+    _VERSION = '0.1.0'
 
 
 def main():
@@ -19,8 +24,9 @@ Examples:
     
     parser.add_argument('input_file', nargs='?', help='Input file path')
     parser.add_argument('output_file', nargs='?', help='Output file path (optional, auto-generated if not provided)')
-    parser.add_argument('--test', type=int, choices=range(1, 9), 
+    parser.add_argument('--test', type=int, choices=range(1, 9),
                         help='Run test case (1-8): 1=LBFGS, 2=NEB, 3=String, 4=Dimer, 5=RFO, 6=IRC, 7=Freq, 8=Scan')
+    parser.add_argument('--version', action='version', version=f'%(prog)s {_VERSION}')
     
     args = parser.parse_args()
     
@@ -67,6 +73,7 @@ Examples:
     
     # Run MAPLE engine
     try:
+        from maple.function.engine import engine
         eng = engine()
         eng(input_file, output_file)
         print(f"\nCalculation completed successfully!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maple"
-version = "0.1.0"
+version = "0.1.1+enhance3.13"
 description = "MAPLE: MAchine-learning Potential for Landscape Exploration"
 requires-python = ">=3.9"
 dependencies = []  # No required dependencies


### PR DESCRIPTION
  ### Fix inline coordinates parsing (`input_reader.py`)

  - **Parsing truncation**: `is_coord_like()` did not recognise charge/multiplicity lines (e.g. `0 1`, `-1 2`), causing
  the molecule block to be cut short when charge/spin were specified inline. Fixed by adding a regex check for
  two-integer lines.

  ### Fix `log_info()` call sites (`input_reader.py`)

  - Two call sites passed bare strings instead of lists to `log_info()`, causing iteration over characters. Fixed by
  wrapping the strings in lists.

  ### Add `--version` flag and bump version to `0.1.1+enhance3.13`

  - Added `--version` argument via `argparse` in `maple/main.py`
  - Lazy-imports the engine so `--version` works without loading heavy dependencies
  - Bumped version in `pyproject.toml` to `0.1.1+enhance3.13`

  ### Cleanup

  - Compress `log_error`/`log_info` docstrings
  - Align `IMPLEMENTATION_MAP` formatting in `command_control.py`