### PR TITLE
PRFO: support recalc/bofill update

### DIFF
--- a/maple/function/dispatcher/irc/irc.py
+++ b/maple/function/dispatcher/irc/irc.py
@@ -5,7 +5,7 @@ from ..jobABC import JobABC
 from maple.function.timer import timer
 
 class IRC(JobABC):
-    def __init__(self, params: dict, output:str, atoms:Atoms, method:str='hpc'):
+    def __init__(self, params: dict, output:str, atoms:Atoms, method:str='gs'):
         super().__init__(output)
         self.atoms = atoms
         self.method = method

--- a/maple/function/dispatcher/ts/algorithm/BPRFO.py
+++ b/maple/function/dispatcher/ts/algorithm/BPRFO.py
@@ -64,7 +64,8 @@ class BatchPRFO:
                  max_inner_attempts: int = 10,
                  max_outer_iter: int = 256,
                  device: str = "cuda",
-                 recalc: int = 4):
+                 recalc: int = 4,
+                 hessian_update: str = "bofill"):
         self.trust_init = trust_init
         self.trust_min = trust_min
         self.trust_max = trust_max
@@ -73,7 +74,10 @@ class BatchPRFO:
         self.max_inner_attempts = max_inner_attempts
         self.max_outer_iter = max_outer_iter
         self.device = torch.device(device)
-        self.recalc = int(recalc)
+        self.recalc = max(1, int(recalc))
+        self.hessian_update = str(hessian_update).lower()
+        if self.hessian_update not in {"bofill", "bfgs"}:
+            raise ValueError("hessian_update must be 'bofill' or 'bfgs'.")
         
         self.output = os.path.abspath(output)
         self.out_dir = os.path.dirname(self.output) or "."
@@ -120,6 +124,7 @@ class BatchPRFO:
         self._open_log()
         self._w("# RS-PRFO batched TS search start\n")
         self._w(f"# RecalcFC interval: {self.recalc}\n")
+        self._w(f"# Hessian update method: {self.hessian_update}\n")
 
         self._init_xyz_paths(B0)
         self._symbols_per_batch = _symbols_flat(atoms_list)
@@ -215,14 +220,22 @@ class BatchPRFO:
 
             # Bofill update: apply ONLY if we didn't just recalculate AND at least one step was accepted
             if not need_recalc and step_accepted.any():
-                self._w(f"[Iter {outer_it}] Applying Bofill update to {step_accepted.sum().item()} batches\n")
-                self._H_work = self._bofill_update_batched(
+                self._w(
+                    f"[Iter {outer_it}] Applying {self.hessian_update.upper()} "
+                    f"update to {step_accepted.sum().item()} batches\n"
+                )
+                update_fn = (
+                    self._bfgs_update_batched
+                    if self.hessian_update == "bfgs"
+                    else self._bofill_update_batched
+                )
+                self._H_work = update_fn(
                     H=self._H_work,
                     s_cart=last_step,
                     g_prev=self._g_cart_prev,
                     g_new=g_new_cart,
                     real_mask=real_mask,
-                    step_accepted=step_accepted  # Pass acceptance mask
+                    step_accepted=step_accepted
                 )
             
             # Always update gradient buffer for next iteration
@@ -673,6 +686,44 @@ class BatchPRFO:
             s_part[b] = s_full
 
         return mu_out, s_part
+
+    @staticmethod
+    @torch.no_grad()
+    def _bfgs_update_batched(
+        H, s_cart, g_prev, g_new, real_mask,
+        step_accepted=None,
+        step_tol: float = 1e-8,
+        grad_tol: float = 1e-8,
+        curvature_tol: float = 1e-12,
+    ):
+        """Symmetric BFGS Hessian update for accepted batched PRFO steps."""
+        DTYPE = H.dtype
+        rm = real_mask.to(DTYPE)
+        mask_ij = (real_mask.unsqueeze(-1) & real_mask.unsqueeze(-2)).to(DTYPE)
+
+        s = s_cart.to(DTYPE) * rm
+        y = (g_new - g_prev).to(DTYPE) * rm
+        upd_mask = ((s * s).sum(-1) > step_tol**2) & ((y * y).sum(-1) > grad_tol**2)
+        if step_accepted is not None:
+            upd_mask = upd_mask & step_accepted
+        if not bool(upd_mask.any()):
+            return H
+
+        H_new = H.clone()
+        for b in upd_mask.nonzero(as_tuple=False).flatten().tolist():
+            sb = s[b]
+            yb = y[b]
+            ys = torch.dot(yb, sb)
+            if ys <= curvature_tol:
+                continue
+            Hs = H[b].matmul(sb)
+            sHs = torch.dot(sb, Hs)
+            if sHs <= curvature_tol:
+                continue
+            Hb = H[b] + torch.outer(yb, yb) / ys - torch.outer(Hs, Hs) / sHs
+            Hb = 0.5 * (Hb + Hb.transpose(-1, -2))
+            H_new[b] = Hb * mask_ij[b] + H_new[b] * (1.0 - mask_ij[b])
+        return H_new
 
     @staticmethod
     @torch.no_grad()

--- a/maple/function/dispatcher/ts/algorithm/PRFO.py
+++ b/maple/function/dispatcher/ts/algorithm/PRFO.py
@@ -350,6 +350,63 @@ def calculate_Hessian(atoms: Atoms):
     H = calc.get_hessian(atoms)
     return to_numpy_f64(H)
 
+def _bfgs_update(H: np.ndarray, s: np.ndarray, y: np.ndarray) -> np.ndarray:
+    """BFGS update of Hessian approximation."""
+    H = to_numpy_f64(H)
+    s = vec1d(s)
+    y = vec1d(y, s.size)
+    ys = float(y.dot(s))
+    if ys <= 1e-12:
+        return H
+    Hs = H.dot(s)
+    sHs = float(s.dot(Hs))
+    if sHs <= 1e-12:
+        return H
+    H_new = H + np.outer(y, y) / ys - np.outer(Hs, Hs) / sHs
+    return 0.5 * (H_new + H_new.T)
+
+def _bofill_update(H: np.ndarray, s: np.ndarray, y: np.ndarray) -> np.ndarray:
+    """
+    Bofill = mixed MS/SR1 + PSB.
+    If the SR1/MS denominator is unsafe, fall back to pure PSB.
+    """
+    H = to_numpy_f64(H)
+    s = vec1d(s)
+    y = vec1d(y, s.size)
+
+    s2 = float(np.dot(s, s))
+    y2 = float(np.dot(y, y))
+    if s2 <= 1e-16 or y2 <= 1e-16:
+        return H
+
+    # Residual: z = Δg - H Δx
+    z = y - H.dot(s)
+    z2 = float(np.dot(z, z))
+    sz = float(np.dot(s, z))
+
+    # PSB term is safe as long as s2 is nonzero, already guaranteed above.
+    psb = (
+        (np.outer(z, s) + np.outer(s, z)) / s2
+        - (sz / (s2 * s2)) * np.outer(s, s)
+    )
+
+    # if s·z is too small, do NOT divide by it; use pure PSB.
+    use_sr1 = (abs(sz) > 1e-8) and (z2 > 1e-16)
+
+    if use_sr1:
+        ms = np.outer(z, z) / sz
+        if s2 > 1e-16 and z2 > 1e-16:
+            ratio = (sz * sz) / (s2 * z2)
+            phi = float(np.clip(1.0 - ratio, 0.0, 1.0))
+        else:
+            phi = 1.0
+    else:
+        ms = np.zeros_like(H)
+        phi = 1.0
+
+    H_new = H + (1.0 - phi) * ms + phi * psb
+    return 0.5 * (H_new + H_new.T)
+
 # =============================================================================
 # ------------------------------- PRFO Parameters -----------------------------
 # =============================================================================
@@ -374,6 +431,8 @@ class PRFOParams:
     evals_eps: float = 1e-10               # Eigenvalue regularization threshold
     mu_margin: float = 1e-8                # Safety margin for bisection
     max_bisect_it: int = 60                # Maximum bisection iterations
+    recalc: int = 1                        # Exact Hessian recalculation interval
+    hessian_update: str = "bofill"         # Working Hessian update: bofill or bfgs
     
     # Convergence thresholds (should be set from atoms object)
     f_max_th: float = 9.5e-3               # Maximum force threshold (Eh/Angstrom)
@@ -403,6 +462,10 @@ class PRFO(JobABC):
 
         # Initialize params from paras dict
         self.params = self._init_params(PRFOParams, paras, ("prfo", "PRFO", "ts"))
+        self.params.recalc = max(1, int(self.params.recalc))
+        self.params.hessian_update = str(self.params.hessian_update).lower()
+        if self.params.hessian_update not in {"bofill", "bfgs"}:
+            raise ValueError("Hessian update method must be 'bofill' or 'bfgs'.")
 
         # Override convergence thresholds from atoms if available
         for attr in ('f_max_th', 'f_rms_th', 'dp_max_th', 'dp_rms_th'):
@@ -617,6 +680,8 @@ class PRFO(JobABC):
         # Log header
         info_message = [
             f"\nStarting Transition State Search (TS) with RS-PRFO...\n",
+            f"Hessian recalc interval: {self.params.recalc}; "
+            f"update method: {self.params.hessian_update}\n",
             f"Trust radius adaptation: eta_shrink={self.params.eta_shrink}, "
             f"eta_expand={self.params.eta_expand}\n",
             f"Convergence thresholds: "
@@ -626,6 +691,8 @@ class PRFO(JobABC):
             f"dp_rms={self.params.dp_rms_th:.6f}\n"
         ]
         log_info(info_message, self.output)
+
+        H_work = None
         
         # Main optimization loop
         while iteration < self.params.max_iter:
@@ -638,12 +705,19 @@ class PRFO(JobABC):
             F_cart = to_numpy_f64(atoms.get_forces())
             g_cart = vec1d(-F_cart)
             
-            # Get Hessian in Cartesian
-            H_cart = to_numpy_f64(calculate_Hessian(atoms))
-            if H_cart.ndim == 3 and H_cart.shape[0] == 1:
-                H_cart = H_cart[0]
-            if H_cart.ndim != 2 or H_cart.shape[0] != H_cart.shape[1]:
-                raise ValueError(f"Hessian must be square, got {H_cart.shape}")
+            need_recalc = (
+                H_work is None
+                or (iteration % self.params.recalc == 0)
+            )
+            if need_recalc:
+                H_cart = to_numpy_f64(calculate_Hessian(atoms))
+                if H_cart.ndim == 3 and H_cart.shape[0] == 1:
+                    H_cart = H_cart[0]
+                if H_cart.ndim != 2 or H_cart.shape[0] != H_cart.shape[1]:
+                    raise ValueError(f"Hessian must be square, got {H_cart.shape}")
+                H_work = H_cart.copy()
+            else:
+                H_cart = H_work
             
             n3 = H_cart.shape[0]
             if g_cart.size != n3:
@@ -743,6 +817,13 @@ class PRFO(JobABC):
                     
                     # Get new forces for convergence check
                     F_new = to_numpy_f64(atoms.get_forces())
+                    g_new_cart = vec1d(-F_new, n3)
+                    if not need_recalc:
+                        y_cart = g_new_cart - g_cart
+                        if self.params.hessian_update == "bfgs":
+                            H_work = _bfgs_update(H_work, s_cart, y_cart)
+                        else:
+                            H_work = _bofill_update(H_work, s_cart, y_cart)
                     
                     # Compute convergence metrics (per DOF RMS)
                     dof = s_cart.size

--- a/maple/function/read/command_control.py
+++ b/maple/function/read/command_control.py
@@ -43,6 +43,7 @@ class CommandControl:
         "sp": {},
         "opt": {},
         "ts": {},
+        "irc": {"method": "gs"},
         "scan": {},
         "freq": {
             "method": "mw",


### PR DESCRIPTION
# Summary

- Added Hessian reuse/update support to PRFO, aligned with BPRFO behavior.
- Fixed IRC default dispatch so `#irc()` runs with GS by default.

# Key Change

- `#ts(method=prfo,recalc=N,hessian_update=bofill|bfgs)` now controls exact Hessian recalculation interval and approximate Hessian updates between recalculations.